### PR TITLE
Fixflaky

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -28,7 +28,7 @@ jobs:
           distribution: 'adopt'
           cache: maven
       - name: Build with Maven
-        run: mvn clean install -DskipTests -pl independent-projects/qute/core -am
+        run: mvn clean install -DskipTests -pl gremlin-core -am
 
       - name: Run specific test
         run: mvn -pl gremlin-core test -Dtest='org.apache.tinkerpop.gremlin.process.traversal.step.util.ParametersTest#shouldAllowNullValues'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,7 +31,7 @@ jobs:
         run: mvn clean install -DskipTests -pl gremlin-core -am
 
       - name: Run specific test
-        run: mvn -pl gremlin-core test -Dtest='org.apache.tinkerpop.gremlin.process.traversal.step.util.ParametersTest#shouldAllowNullValues'
+        run: mvn -pl gremlin-core test -Dtest='org.apache.tinkerpop.gremlin.process.traversal.step.map.ConjoinStepTest#testReturnTypes'
 
       - name: Run specific test using NON-DEX
-        run: mvn -pl gremlin-core edu.illinois:nondex-maven-plugin:2.1.1:nondex -DnondexRunsWithoutShuffling=10 -Dtest='org.apache.tinkerpop.gremlin.process.traversal.step.util.ParametersTest#shouldAllowNullValues'
+        run: mvn -pl gremlin-core edu.illinois:nondex-maven-plugin:2.1.1:nondex -DnondexRunsWithoutShuffling=10 -Dtest='org.apache.tinkerpop.gremlin.process.traversal.step.map.ConjoinStepTest#testReturnTypes'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '8'
-          distribution: 'oracle'
+          distribution: 'temurin'
       - name: Build with Maven
         run: mvn clean install -DskipTests -pl independent-projects/qute/core -am
 

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/setup-java@v4
         with:
           java-version: '8'
-          distribution: 'temurin'
+          distribution: 'adopt'
           cache: maven
       - name: Build with Maven
         run: mvn clean install -DskipTests -pl independent-projects/qute/core -am

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,36 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Java CI with Maven
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: '8'
+          distribution: 'oracle'
+      - name: Build with Maven
+        run: mvn clean install -DskipTests -pl independent-projects/qute/core -am
+
+      - name: Run specific test
+        run: mvn -pl gremlin-core test -Dtest='org.apache.tinkerpop.gremlin.process.traversal.step.util.ParametersTest#shouldAllowNullValues'
+
+      - name: Run specific test using NON-DEX
+        run: mvn -pl gremlin-core edu.illinois:nondex-maven-plugin:2.1.1:nondex -DnondexRunsWithoutShuffling=10 -Dtest='org.apache.tinkerpop.gremlin.process.traversal.step.util.ParametersTest#shouldAllowNullValues'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           java-version: '8'
           distribution: 'temurin'
+          cache: maven
       - name: Build with Maven
         run: mvn clean install -DskipTests -pl independent-projects/qute/core -am
 

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ConjoinStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ConjoinStepTest.java
@@ -36,9 +36,7 @@ import static org.junit.Assert.fail;
 
 public class ConjoinStepTest extends StepTest {
     @Override
-    protected List<Traversal> getTraversals() {
-        return Collections.singletonList(__.conjoin("a"));
-    }
+    protected List<Traversal> getTraversals() { return Collections.singletonList(__.conjoin("a")); }
 
     @Test
     public void testReturnTypes() {
@@ -50,15 +48,13 @@ public class ConjoinStepTest extends StepTest {
         }
 
         assertEquals("", __.__(Collections.emptyList()).conjoin("a").next());
-        assertEquals("5AA8AA10", __.__(new long[] { 5L, 8L, 10L }).conjoin("AA").next());
-        assertEquals("715", __.__(1).constant(new Long[] { 7L, 15L }).conjoin("").next());
-        assertEquals("5.5,8.0,10.1", __.__(new double[] { 5.5, 8.0, 10.1 }).conjoin(",").next());
+        assertEquals("5AA8AA10", __.__(new long[] {5L, 8L, 10L}).conjoin("AA").next());
+        assertEquals("715", __.__(1).constant(new Long[] {7L, 15L}).conjoin("").next());
+        assertEquals("5.5,8.0,10.1", __.__(new double[] {5.5, 8.0, 10.1}).conjoin(",").next());
         assertNull(__.__(Arrays.asList(null, null)).conjoin(",").next());
 
         final Set<Integer> set = new LinkedHashSet<>();
-        set.add(10);
-        set.add(11);
-        set.add(12);
+        set.add(10); set.add(11); set.add(12);
         assertEquals("10.11.12", __.__(set).conjoin(".").next());
     }
 }

--- a/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ConjoinStepTest.java
+++ b/gremlin-core/src/test/java/org/apache/tinkerpop/gremlin/process/traversal/step/map/ConjoinStepTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -36,7 +36,9 @@ import static org.junit.Assert.fail;
 
 public class ConjoinStepTest extends StepTest {
     @Override
-    protected List<Traversal> getTraversals() { return Collections.singletonList(__.conjoin("a")); }
+    protected List<Traversal> getTraversals() {
+        return Collections.singletonList(__.conjoin("a"));
+    }
 
     @Test
     public void testReturnTypes() {
@@ -48,13 +50,15 @@ public class ConjoinStepTest extends StepTest {
         }
 
         assertEquals("", __.__(Collections.emptyList()).conjoin("a").next());
-        assertEquals("5AA8AA10", __.__(new long[] {5L, 8L, 10L}).conjoin("AA").next());
-        assertEquals("715", __.__(1).constant(new Long[] {7L, 15L}).conjoin("").next());
-        assertEquals("5.5,8.0,10.1", __.__(new double[] {5.5, 8.0, 10.1}).conjoin(",").next());
+        assertEquals("5AA8AA10", __.__(new long[] { 5L, 8L, 10L }).conjoin("AA").next());
+        assertEquals("715", __.__(1).constant(new Long[] { 7L, 15L }).conjoin("").next());
+        assertEquals("5.5,8.0,10.1", __.__(new double[] { 5.5, 8.0, 10.1 }).conjoin(",").next());
         assertNull(__.__(Arrays.asList(null, null)).conjoin(",").next());
 
-        final Set<Integer> set = new HashSet<>();
-        set.add(10); set.add(11); set.add(12);
+        final Set<Integer> set = new LinkedHashSet<>();
+        set.add(10);
+        set.add(11);
+        set.add(12);
         assertEquals("10.11.12", __.__(set).conjoin(".").next());
     }
 }


### PR DESCRIPTION
## What is the purpose of this PR

This PR addresses an issue with the ConjoinStepTest class where nondeterministic iteration order of HashSet could potentially lead to flaky tests. The changes involve replacing HashSet with LinkedHashSet to ensure a predictable iteration order and thus more reliable test outcomes.

## Why the tests fail

The tests failed due to the unpredictable ordering of elements in a HashSet, causing inconsistent outcomes. Switching to LinkedHashSet fixed this by ensuring a stable element order.

## Reproduce the test failure


## Expected results

- Test should run successfully when run with NonDex

## Actual Result

- We get the following failure for the test

<img width="1035" alt="Screenshot 2024-03-14 at 9 43 50 PM" src="https://github.com/SaikiranReddyKudumula/tinkerpop/assets/56921559/69ea287e-dfff-493b-98b6-fb157caeacb9">


## Fix

The original code used a HashSet to store elements, which does not guarantee the order of its elements. In tests where the expected outcome was based on the specific order of elements in a set, this could lead to intermittent test failures, because the HashSet could provide different element orders in different runs.

The fix addressed this issue by replacing HashSet with LinkedHashSet. LinkedHashSet maintains the order of elements as they were inserted, ensuring that the order is predictable and consistent across test runs. This change made the tests reliable by guaranteeing that the order of elements in the set matches the expected order defined in the test assertions, thus eliminating the source of flakiness.